### PR TITLE
Updating ractive version and adjusting template object terminal based on type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-ractive-parse",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Pre-parse Ractive templates for use in ExtJS or other MVC projects",
   "homepage": "https://github.com/alisonailea/grunt-ractive-parse",
   "repository": {
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "chalk": "~0.4.0",
-    "ractive": "~0.4.0"
+    "ractive": "^0.5.5"
   },
   "devDependencies": {
     "grunt-contrib-clean": "^0.5.0",

--- a/tasks/ractiveparse.js
+++ b/tasks/ractiveparse.js
@@ -59,6 +59,9 @@
 
             // Define destination type
             options.destSyntax = setType(file.dest);
+            
+            // Define terminal type
+            options.terminalSyntax = setTerminal();
 
             // Parse the template src files
             file.src.map(parse);
@@ -69,13 +72,28 @@
 
             // Join parsed files and write them to a new file.
             grunt.file.write(file.dest,
-                options.destSyntax + " {" + templateOptions + templates.join(",\n") + "\n\n});");
+                options.destSyntax + " {" + templateOptions + templates.join(",\n") + "\n\n}" + options.terminalSyntax);
 
             // Log success.
             grunt.log.writeln('File "' + chalk.cyan(file.dest) + '" created.');
         });
 
         templateJson = {};
+    }
+    
+    function setTerminal() {
+      switch (options.type) {
+        case: 'javascript':
+          return ';';
+          
+        case: 'extjs':
+          return ');';
+          
+        default:
+          // warning
+          grunt.fail.warn('Unrecognized type. Please choose "javascript" or "extjs"\n');
+          return false;
+      }
     }
 
     function setType(filePath){

--- a/tasks/ractiveparse.js
+++ b/tasks/ractiveparse.js
@@ -83,10 +83,10 @@
     
     function setTerminal() {
       switch (options.type) {
-        case: 'javascript':
+        case 'javascript':
           return ';';
           
-        case: 'extjs':
+        case 'extjs':
           return ');';
           
         default:


### PR DESCRIPTION
Thanks for this module!

I updated ractive to 0.5.5 and set the flag to ^ so that it stays with the latest version. Currently if you include the latest ractive from cdn and use this to compile, you get the error: `Uncaught Error: Mismatched template version! Please ensure you are using the latest version of Ractive.js in your build process as well as in your app`.

The other thing I did was add a small function which adjusts the template object terminal to vary based on type. You had it always return `});` which was throwing errors when you use the normal javascript object setting which opens with `javascript var template = {`. I set it to select `});` if ext and `};` if javascript.
